### PR TITLE
Extend PullRequest interface to expose typing for base.ref nested property

### DIFF
--- a/src/TriggerEvent.ts
+++ b/src/TriggerEvent.ts
@@ -152,6 +152,9 @@ export interface PullRequest {
   review_comment_url: string;
   comments_url: string;
   statuses_url: string;
+  base: {
+    ref: string
+  }
   // TODO: way more stuff goes here
 }
 


### PR DESCRIPTION
The library already allows generating GitHub actions that are able to reference the `base.ref` property of the `pull_request` event (`github.event.pull_request.base.ref`), with this change this operation will become properly typed.