### PR TITLE
 feat!: Update actions/cache and actions/checkout to v4

### DIFF
--- a/.github/workflows-src/rollingversions.ts
+++ b/.github/workflows-src/rollingversions.ts
@@ -13,7 +13,7 @@ export default createWorkflow(({setWorkflowName, addTrigger, addJob}) => {
 
   addJob('publish', ({addDependencies, add, run, use}) => {
     addDependencies(testJob);
-    use('actions/checkout@v2');
+    use('actions/checkout@v4');
     use('actions/setup-node@v1', {
       with: {
         'node-version': '12.x',

--- a/.github/workflows/rollingversions.yml
+++ b/.github/workflows/rollingversions.yml
@@ -20,14 +20,14 @@ jobs:
           - 18.x
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org
       - name: Enable Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('package.json',
             'yarn.lock') }}
@@ -83,13 +83,13 @@ jobs:
       - test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
           registry-url: https://registry.npmjs.org
       - name: Enable Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-12.x-${{ hashFiles('package.json', 'yarn.lock') }}
           path: node_modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,14 @@ jobs:
           - 18.x
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org
       - name: Enable Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('package.json',
             'yarn.lock') }}

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -19,7 +19,7 @@ export interface CheckoutOptions {
 }
 export function checkout(options: CheckoutOptions = {}): Steps {
   return ({use}) => {
-    use(options.stepName || 'Git Checkout', 'actions/checkout@v3', {
+    use(options.stepName || 'Git Checkout', 'actions/checkout@v4', {
       with: {
         repository: options.repository,
         ref: options.ref,
@@ -82,7 +82,7 @@ export function cache({
   return ({use}) => {
     const {outputs} = use<{'cache-hit': string}>(
       stepName || 'Enable Cache',
-      'actions/cache@v3',
+      'actions/cache@v4',
       {
         with: {
           key,


### PR DESCRIPTION
Those two actions rely on node16, soon not supported by github

 https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default